### PR TITLE
feat : 각 도메인별 API 호출 통계를 기록할 수 있도록 기능 추가

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,8 +4,19 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="db0b6a8e-5ee2-4766-83ca-070d992366d0" name="변경" comment="# &lt;타입&gt;: &lt;제목&gt;&#10;refactor : 불필요한 print문 제거 및 import 경로 변경&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------">
-      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/global/exception/ControllerExceptionHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/global/exception/ExceptionHandler.java" afterDir="false" />
+    <list default="true" id="db0b6a8e-5ee2-4766-83ca-070d992366d0" name="변경" comment="# &lt;타입&gt;: &lt;제목&gt;&#10;&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/admin/controller/UserAdminController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/admin/controller/UserAdminController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/apilogger/ApiLogger.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/apilogger/ApiLogger.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/apilogger/service/ApiLoggerService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/apilogger/service/ApiLoggerService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/evaluation/controller/EvaluateController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/evaluation/controller/EvaluateController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/exam/controller/ExamPostsController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/exam/controller/ExamPostsController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/lecture/controller/LectureController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/lecture/controller/LectureController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/notice/controller/NoticeController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/notice/controller/NoticeController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/user/controller/UserController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/user/controller/UserController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/global/VersionController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/global/VersionController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/global/annotation/ApiLogAspect.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/global/annotation/ApiLogAspect.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/global/annotation/ApiLogger.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/global/annotation/ApiLogger.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -84,6 +95,10 @@
               <option name="branches">
                 <list>
                   <RecentBranch>
+                    <option name="branchName" value="Feature_kdh_005" />
+                    <option name="lastUsedInstant" value="1680341752" />
+                  </RecentBranch>
+                  <RecentBranch>
                     <option name="branchName" value="Develop_kdh_001" />
                     <option name="lastUsedInstant" value="1670493304" />
                   </RecentBranch>
@@ -98,10 +113,6 @@
                   <RecentBranch>
                     <option name="branchName" value="Feature_kdh_004" />
                     <option name="lastUsedInstant" value="1656139007" />
-                  </RecentBranch>
-                  <RecentBranch>
-                    <option name="branchName" value="HotFix" />
-                    <option name="lastUsedInstant" value="1656084749" />
                   </RecentBranch>
                 </list>
               </option>
@@ -144,25 +155,25 @@
     <option name="showLibraryContents" value="true" />
     <option name="sortByType" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RequestMappingsPanelOrder0": "0",
-    "RequestMappingsPanelOrder1": "1",
-    "RequestMappingsPanelOrder2": "2",
-    "RequestMappingsPanelWidth0": "75",
-    "RequestMappingsPanelWidth1": "75",
-    "RequestMappingsPanelWidth2": "75",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "WebServerToolWindowFactoryState": "false",
-    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
-    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
-    "last_opened_file_path": "E:/Priority/Project/SUWIKI-REMASTER/src/main/java/usw/suwiki/global",
-    "nodejs_package_manager_path": "npm",
-    "settings.editor.selected.configurable": "preferences.pluginManager",
-    "spring.configuration.checksum": "1e934fca0325313c5fddbb07460f1f9d"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RequestMappingsPanelOrder0&quot;: &quot;0&quot;,
+    &quot;RequestMappingsPanelOrder1&quot;: &quot;1&quot;,
+    &quot;RequestMappingsPanelOrder2&quot;: &quot;2&quot;,
+    &quot;RequestMappingsPanelWidth0&quot;: &quot;75&quot;,
+    &quot;RequestMappingsPanelWidth1&quot;: &quot;75&quot;,
+    &quot;RequestMappingsPanelWidth2&quot;: &quot;75&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
+    &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary&quot;: &quot;JUnit5&quot;,
+    &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5&quot;: &quot;&quot;,
+    &quot;last_opened_file_path&quot;: &quot;E:/Priority/Project/SUWIKI-REMASTER/src/main/java/usw/suwiki/global&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.pluginManager&quot;,
+    &quot;spring.configuration.checksum&quot;: &quot;1e934fca0325313c5fddbb07460f1f9d&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="E:\Priority\Project\SUWIKI-REMASTER\src\main\java\usw\suwiki\global" />
@@ -358,14 +369,8 @@
       <workItem from="1677047659515" duration="580000" />
       <workItem from="1677230478111" duration="195000" />
       <workItem from="1680340590866" duration="180000" />
-      <workItem from="1680340799469" duration="663000" />
-    </task>
-    <task id="LOCAL-00107" summary="# &lt;타입&gt;: &lt;제목&gt;&#10;feat&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------">
-      <created>1659692460106</created>
-      <option name="number" value="00107" />
-      <option name="presentableId" value="LOCAL-00107" />
-      <option name="project" value="LOCAL" />
-      <updated>1659692460106</updated>
+      <workItem from="1680340799469" duration="1769000" />
+      <workItem from="1680420395186" duration="4858000" />
     </task>
     <task id="LOCAL-00108" summary="# &lt;타입&gt;: &lt;제목&gt;&#10;feat&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------">
       <created>1659692624373</created>
@@ -703,7 +708,14 @@
       <option name="project" value="LOCAL" />
       <updated>1680341203478</updated>
     </task>
-    <option name="localTasksCounter" value="156" />
+    <task id="LOCAL-00156" summary="# &lt;타입&gt;: &lt;제목&gt;&#10;test : commit for merge conflict solving&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------">
+      <created>1680341921589</created>
+      <option name="number" value="00156" />
+      <option name="presentableId" value="LOCAL-00156" />
+      <option name="project" value="LOCAL" />
+      <updated>1680341921589</updated>
+    </task>
+    <option name="localTasksCounter" value="157" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -737,7 +749,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="# &lt;타입&gt;: &lt;제목&gt;&#10;fix : 신고 게시글 삭제 버그 수정&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------" />
     <MESSAGE value="# &lt;타입&gt;: &lt;제목&gt;&#10;refactor : UserAdminController Repository 의존성 제거 및 기존 컨트롤러 내 부가적인 비즈니스 로직을 UseCase로 캡슐화 &#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------" />
     <MESSAGE value="# &lt;타입&gt;: &lt;제목&gt;&#10;refactor : UserAdminRestrict 비즈니스 로직 유스케이스로 캡슐화&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------" />
     <MESSAGE value="# &lt;타입&gt;: &lt;제목&gt;&#10;refactor : UserController 비즈니스 로직 유스케이스 캡슐화&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------" />
@@ -762,6 +773,7 @@
     <MESSAGE value="# &lt;타입&gt;: &lt;제목&gt;&#10;refactor : 회원탈퇴 시 유예기간 동안 아이디/이메일 중복확인에 걸릴 수 있도록 &#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------" />
     <MESSAGE value="# &lt;타입&gt;: &lt;제목&gt;&#10;feat/refactor : API Logger 추가 및 코드 재정렬&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------" />
     <MESSAGE value="# &lt;타입&gt;: &lt;제목&gt;&#10;refactor : 불필요한 print문 제거 및 import 경로 변경&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------" />
-    <option name="LAST_COMMIT_MESSAGE" value="# &lt;타입&gt;: &lt;제목&gt;&#10;refactor : 불필요한 print문 제거 및 import 경로 변경&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------" />
+    <MESSAGE value="# &lt;타입&gt;: &lt;제목&gt;&#10;test : commit for merge conflict solving&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------" />
+    <option name="LAST_COMMIT_MESSAGE" value="# &lt;타입&gt;: &lt;제목&gt;&#10;test : commit for merge conflict solving&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------" />
   </component>
 </project>

--- a/src/main/java/usw/suwiki/domain/admin/controller/UserAdminController.java
+++ b/src/main/java/usw/suwiki/domain/admin/controller/UserAdminController.java
@@ -47,7 +47,7 @@ public class UserAdminController {
     private final UserAdminLoadDetailReportingPostService userAdminLoadDetailReportingPostService;
 
     // 관리자 전용 로그인 API
-    @ApiLogger
+    @ApiLogger(option = "admin")
     @PostMapping("/login")
     public ResponseEntity<Map<String, String>> administratorLogin(
         @Valid @RequestBody LoginForm loginForm) {
@@ -57,7 +57,7 @@ public class UserAdminController {
     }
 
     // 강의평가 게시물 정지 먹이기
-    @ApiLogger
+    @ApiLogger(option = "admin")
     @PostMapping("/restrict/evaluate-post")
     public ResponseEntity<Map<String, Boolean>> restrictEvaluatePost(
         @Valid @RequestHeader String Authorization,
@@ -71,7 +71,7 @@ public class UserAdminController {
     }
 
     // 시험정보 게시물 정지 먹이기
-    @ApiLogger
+    @ApiLogger(option = "admin")
     @PostMapping("/restrict/exam-post")
     public ResponseEntity<Map<String, Boolean>> restrictExamPost(
         @Valid @RequestHeader String Authorization,
@@ -86,7 +86,7 @@ public class UserAdminController {
 
 
     // 강의평가 게시물 블랙리스트 먹이기
-    @ApiLogger
+    @ApiLogger(option = "admin")
     @PostMapping("/blacklist/evaluate-post")
     public ResponseEntity<Map<String, Boolean>> banEvaluatePost(
         @Valid @RequestHeader String Authorization,
@@ -100,7 +100,7 @@ public class UserAdminController {
     }
 
     // 시험정보 게시물 블랙리스트 먹이기
-    @ApiLogger
+    @ApiLogger(option = "admin")
     @PostMapping("/blacklist/exam-post")
     public ResponseEntity<Map<String, Boolean>> banExamPost(
         @Valid @RequestHeader String Authorization,
@@ -114,7 +114,7 @@ public class UserAdminController {
     }
 
     // 이상 없는 신고 강의평가 게시글이면 지워주기
-    @ApiLogger
+    @ApiLogger(option = "admin")
     @PostMapping("/no-problem/evaluate-post")
     public ResponseEntity<Map<String, Boolean>> noProblemEv(
         @Valid @RequestHeader String Authorization,
@@ -128,7 +128,7 @@ public class UserAdminController {
     }
 
     // 이상 없는 신고 시험정보 게시글이면 지워주기
-    @ApiLogger
+    @ApiLogger(option = "admin")
     @PostMapping("/no-problem/exam-post")
     public ResponseEntity<Map<String, Boolean>> noProblemEx(
         @Valid @RequestHeader String Authorization,
@@ -142,7 +142,7 @@ public class UserAdminController {
     }
 
     // 신고받은 게시글 리스트 불러오기
-    @ApiLogger
+    @ApiLogger(option = "admin")
     @GetMapping("/report/list")
     public ResponseEntity<LoadAllReportedPostForm> loadReportedPost(
         @Valid @RequestHeader String Authorization) {
@@ -156,7 +156,7 @@ public class UserAdminController {
 
 
     // 강의평가에 관련된 신고 게시글 자세히 보기
-    @ApiLogger
+    @ApiLogger(option = "admin")
     @GetMapping("/report/evaluate/")
     public ResponseEntity<EvaluatePostReport> loadDetailReportedEvaluatePost(
         @Valid @RequestHeader String Authorization,
@@ -169,7 +169,7 @@ public class UserAdminController {
     }
 
     // 시험정보에 관련된 신고 게시글 자세히 보기
-    @ApiLogger
+    @ApiLogger(option = "admin")
     @GetMapping("/report/exam/")
     public ResponseEntity<ExamPostReport> loadDetailReportedExamPost(
         @Valid @RequestHeader String Authorization,

--- a/src/main/java/usw/suwiki/domain/apilogger/ApiLogger.java
+++ b/src/main/java/usw/suwiki/domain/apilogger/ApiLogger.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class ApiLogger {
 
     @Id
@@ -24,16 +24,123 @@ public class ApiLogger {
     private Long id;
 
     @Column
-    private Long callTime;
+    private Long totalApiCallTime;
 
     @Column
-    private Long processAvg;
+    private Long totalApiProcessAvg;
+
+    @Column
+    private Long lectureApiCallTime;
+
+    @Column
+    private Long lectureApiProcessAvg;
+
+    @Column
+    private Long evaluatePostsApiCallTime;
+
+    @Column
+    private Long evaluatePostsApiProcessAvg;
+
+    @Column
+    private Long examPostsApiCallTime;
+
+    @Column
+    private Long examPostsApiProcessAvg;
+
+    @Column
+    private Long userApiCallTime;
+
+    @Column
+    private Long userApiProcessAvg;
+
+    @Column
+    private Long noticeApiCallTime;
+
+    @Column
+    private Long noticeApiProcessAvg;
 
     @Column
     private LocalDate callDate;
 
-    public void calculateProcessAvg(Long currentProcessTime) {
-        this.processAvg = (currentProcessTime + (processAvg * callTime)) / (this.callTime + 1);
-        this.callTime += 1;
+    public ApiLogger saveNewLectureStatistics(LocalDate today, Long currentProcessTime) {
+        return ApiLogger.builder()
+            .lectureApiCallTime(1L)
+            .callDate(today)
+            .lectureApiProcessAvg(currentProcessTime)
+            .build();
+    }
+
+    public ApiLogger saveNewEvaluatePostsStatistics(LocalDate today, Long currentProcessTime) {
+        return ApiLogger.builder()
+            .evaluatePostsApiCallTime(1L)
+            .callDate(today)
+            .evaluatePostsApiProcessAvg(currentProcessTime)
+            .build();
+    }
+
+    public ApiLogger saveNewExamPostsStatistics(LocalDate today, Long currentProcessTime) {
+        return ApiLogger.builder()
+            .examPostsApiCallTime(1L)
+            .callDate(today)
+            .examPostsApiProcessAvg(currentProcessTime)
+            .build();
+    }
+
+    public ApiLogger saveNewUserStatistics(LocalDate today, Long currentProcessTime) {
+        return ApiLogger.builder()
+            .userApiCallTime(1L)
+            .callDate(today)
+            .userApiProcessAvg(currentProcessTime)
+            .build();
+    }
+
+    public ApiLogger saveNewNoticeStatistics(LocalDate today, Long currentProcessTime) {
+        return ApiLogger.builder()
+            .noticeApiCallTime(1L)
+            .callDate(today)
+            .noticeApiProcessAvg(currentProcessTime)
+            .build();
+    }
+
+    public void calculateTotalApiStatistics(Long currentProcessTime) {
+        this.totalApiProcessAvg =
+            (currentProcessTime + (totalApiProcessAvg * totalApiCallTime)) /
+                (this.totalApiCallTime + 1);
+        this.totalApiCallTime += 1;
+    }
+
+    public void calculateLectureApiStatistics(Long currentProcessTime) {
+        this.lectureApiProcessAvg =
+            (currentProcessTime + (lectureApiProcessAvg * lectureApiCallTime)) /
+                (this.lectureApiCallTime + 1);
+        this.lectureApiCallTime += 1;
+    }
+
+    public void calculateEvaluatePostsApiStatistics(Long currentProcessTime) {
+        this.evaluatePostsApiProcessAvg =
+            (currentProcessTime + (evaluatePostsApiProcessAvg * evaluatePostsApiCallTime)) /
+                (this.evaluatePostsApiCallTime + 1);
+        this.evaluatePostsApiCallTime += 1;
+    }
+
+    public void calculateExamPostsStatistics(Long currentProcessTime) {
+        this.examPostsApiProcessAvg =
+            (currentProcessTime + (examPostsApiProcessAvg * examPostsApiCallTime)) /
+                (this.examPostsApiCallTime + 1);
+        this.examPostsApiCallTime += 1;
+    }
+
+    public void calculateUserApiStatistics(Long currentProcessTime) {
+        this.userApiProcessAvg =
+            (currentProcessTime + (userApiProcessAvg * userApiCallTime)) /
+                (this.userApiCallTime + 1);
+        this.userApiCallTime += 1;
+    }
+
+    public void calculateNoticeApiStatistics(Long currentProcessTime) {
+        this.noticeApiProcessAvg =
+            (currentProcessTime + (noticeApiProcessAvg * noticeApiCallTime)) /
+                (this.noticeApiCallTime + 1);
+        this.noticeApiCallTime += 1;
     }
 }

--- a/src/main/java/usw/suwiki/domain/apilogger/service/ApiLoggerService.java
+++ b/src/main/java/usw/suwiki/domain/apilogger/service/ApiLoggerService.java
@@ -15,20 +15,54 @@ public class ApiLoggerService {
 
     private final ApiLoggerRepository apiLoggerRepository;
 
-    @Transactional
-    public void logApi(LocalDate today, Long currentProcessTime) {
-        Optional<ApiLogger> apiLogger = apiLoggerRepository.findByCallDate(today);
+    private final String lecturePostsOption = "lecture";
+    private final String evaluatePostsOption = "evaluatePosts";
+    private final String examPostsOption = "examPosts";
+    private final String userOption = "user";
+    private final String noticeOption = "notice";
 
+    @Transactional
+    public void logApi(LocalDate today, Long currentProcessTime, String option) {
+        Optional<ApiLogger> apiLogger = apiLoggerRepository.findByCallDate(today);
         if (apiLogger.isEmpty()) {
-            ApiLogger newTodayApiLogger = ApiLogger.builder()
-                .callTime(1L)
-                .callDate(today)
-                .processAvg(currentProcessTime)
-                .build();
-            apiLoggerRepository.save(newTodayApiLogger);
+            apiLoggerRepository.save(makeNewApiStatistics(today, currentProcessTime, option));
             return;
         }
-        apiLogger.get().calculateProcessAvg(currentProcessTime);
-        apiLoggerRepository.save(apiLogger.get());
+        apiLoggerRepository.save(makeOldApiStatistics(apiLogger.get(), currentProcessTime, option));
+    }
+
+    private ApiLogger makeNewApiStatistics(
+        LocalDate today, Long currentProcessTime, String option
+    ) {
+        ApiLogger newApiLogger = new ApiLogger();
+        if (option.equals(lecturePostsOption)) {
+            newApiLogger.saveNewLectureStatistics(today, currentProcessTime);
+        } else if (option.equals(evaluatePostsOption)) {
+            newApiLogger.saveNewEvaluatePostsStatistics(today, currentProcessTime);
+        } else if (option.equals(examPostsOption)) {
+            newApiLogger.saveNewExamPostsStatistics(today, currentProcessTime);
+        } else if (option.equals(userOption)) {
+            newApiLogger.saveNewUserStatistics(today, currentProcessTime);
+        } else if (option.equals(noticeOption)) {
+            newApiLogger.saveNewNoticeStatistics(today, currentProcessTime);
+        }
+        return newApiLogger;
+    }
+
+    private ApiLogger makeOldApiStatistics(
+        ApiLogger apiLogger, Long currentProcessTime, String option
+    ) {
+        if (option.equals(lecturePostsOption)) {
+            apiLogger.calculateLectureApiStatistics(currentProcessTime);
+        } else if (option.equals(evaluatePostsOption)) {
+            apiLogger.calculateEvaluatePostsApiStatistics(currentProcessTime);
+        } else if (option.equals(examPostsOption)) {
+            apiLogger.calculateExamPostsStatistics(currentProcessTime);
+        } else if (option.equals(userOption)) {
+            apiLogger.calculateUserApiStatistics(currentProcessTime);
+        } else if (option.equals(noticeOption)) {
+            apiLogger.calculateNoticeApiStatistics(currentProcessTime);
+        }
+        return apiLogger;
     }
 }

--- a/src/main/java/usw/suwiki/domain/evaluation/controller/EvaluateController.java
+++ b/src/main/java/usw/suwiki/domain/evaluation/controller/EvaluateController.java
@@ -40,7 +40,7 @@ public class EvaluateController {
     private final JwtTokenValidator jwtTokenValidator;
     private final JwtTokenResolver jwtTokenResolver;
 
-    @ApiLogger
+    @ApiLogger(option = "evaluatePosts")
     @GetMapping
     public ResponseEntity<FindByLectureToJson> findByLecture(@RequestHeader String Authorization,
         @RequestParam Long lectureId,
@@ -63,7 +63,7 @@ public class EvaluateController {
         }
     }
 
-    @ApiLogger
+    @ApiLogger(option = "evaluatePosts")
     @PutMapping
     public ResponseEntity<String> updateEvaluatePosts(@RequestParam Long evaluateIdx,
         @RequestHeader String Authorization, @RequestBody EvaluatePostsUpdateDto dto) {
@@ -80,7 +80,7 @@ public class EvaluateController {
         }
     }
 
-    @ApiLogger
+    @ApiLogger(option = "evaluatePosts")
     @PostMapping
     public ResponseEntity<String> saveEvaluatePosts(@RequestParam Long lectureId,
         @RequestHeader String Authorization, @RequestBody EvaluatePostsSaveDto dto)
@@ -104,7 +104,7 @@ public class EvaluateController {
         }
     }
 
-    @ApiLogger
+    @ApiLogger(option = "evaluatePosts")
     @GetMapping("/written") // 이름 수정 , 널값 처리 프론트
     public ResponseEntity<ToJsonArray> findByUser(@RequestHeader String Authorization,
         @RequestParam(required = false) Optional<Integer> page) {
@@ -125,7 +125,7 @@ public class EvaluateController {
         }
     }
 
-    @ApiLogger
+    @ApiLogger(option = "evaluatePosts")
     @DeleteMapping
     public ResponseEntity<String> deleteEvaluatePosts(@RequestParam Long evaluateIdx,
         @RequestHeader String Authorization) {

--- a/src/main/java/usw/suwiki/domain/exam/controller/ExamPostsController.java
+++ b/src/main/java/usw/suwiki/domain/exam/controller/ExamPostsController.java
@@ -44,7 +44,7 @@ public class ExamPostsController {
     private final JwtTokenResolver jwtTokenResolver;
     private final ViewExamService viewExamService;
 
-    @ApiLogger
+    @ApiLogger(option = "examPosts")
     @GetMapping
     public ResponseEntity<FindByLectureToExam> findByLecture(@RequestParam Long lectureId,
         @RequestHeader String Authorization,
@@ -80,7 +80,7 @@ public class ExamPostsController {
         }
     }
 
-    @ApiLogger
+    @ApiLogger(option = "examPosts")
     @PostMapping("/purchase")
     public ResponseEntity<String> buyExamInfo(@RequestParam Long lectureId,
         @RequestHeader String Authorization) {
@@ -96,7 +96,7 @@ public class ExamPostsController {
         }
     }
 
-    @ApiLogger
+    @ApiLogger(option = "examPosts")
     @PostMapping
     public ResponseEntity<String> saveExamPosts(@RequestParam Long lectureId,
         @RequestBody ExamPostsSaveDto dto, @RequestHeader String Authorization) throws IOException {
@@ -117,7 +117,7 @@ public class ExamPostsController {
         }
     }
 
-    @ApiLogger
+    @ApiLogger(option = "examPosts")
     @PutMapping
     public ResponseEntity<String> updateExamPosts(@RequestParam Long examIdx,
         @RequestHeader String Authorization, @RequestBody ExamPostsUpdateDto dto) {
@@ -134,7 +134,7 @@ public class ExamPostsController {
         }
     }
 
-    @ApiLogger
+    @ApiLogger(option = "examPosts")
     @GetMapping("/written") // 이름 수정 , 널값 처리 프론트
     public ResponseEntity<ToJsonArray> findByUser(@RequestHeader String Authorization,
         @RequestParam(required = false) Optional<Integer> page) {
@@ -155,7 +155,7 @@ public class ExamPostsController {
         }
     }
 
-    @ApiLogger
+    @ApiLogger(option = "examPosts")
     @DeleteMapping
     public ResponseEntity<String> deleteExamPosts(@RequestParam Long examIdx,
         @RequestHeader String Authorization) {
@@ -177,7 +177,7 @@ public class ExamPostsController {
         }
     }
 
-    @ApiLogger
+    @ApiLogger(option = "examPosts")
     @GetMapping("/purchase") // 이름 수정 , 널값 처리 프론트
     public ResponseEntity<ToJsonArray> showPurchaseHistory(@RequestHeader String Authorization) {
         HttpHeaders header = new HttpHeaders();

--- a/src/main/java/usw/suwiki/domain/lecture/controller/LectureController.java
+++ b/src/main/java/usw/suwiki/domain/lecture/controller/LectureController.java
@@ -31,7 +31,7 @@ public class LectureController {
     private final JwtTokenValidator jwtTokenValidator;
     private final JwtTokenResolver jwtTokenResolver;
 
-    @ApiLogger
+    @ApiLogger(option = "lecture")
     @GetMapping("/search")
     public ResponseEntity<LectureToJsonArray> findByLectureSearchValue(
         @RequestParam String searchValue,
@@ -56,7 +56,7 @@ public class LectureController {
         }
     }
 
-    @ApiLogger
+    @ApiLogger(option = "lecture")
     @GetMapping("/all")
     public ResponseEntity<LectureToJsonArray> findAllList(
         @RequestParam(required = false) Optional<String> option,
@@ -74,7 +74,7 @@ public class LectureController {
         }
     }
 
-    @ApiLogger
+    @ApiLogger(option = "lecture")
     @GetMapping
     public ResponseEntity<ToJsonArray> findLectureByLectureId(@RequestParam Long lectureId,
         @RequestHeader String Authorization) {

--- a/src/main/java/usw/suwiki/domain/notice/controller/NoticeController.java
+++ b/src/main/java/usw/suwiki/domain/notice/controller/NoticeController.java
@@ -38,7 +38,7 @@ public class NoticeController {
     private final JwtTokenValidator jwtTokenValidator;
     private final JwtTokenResolver jwtTokenResolver;
 
-    @ApiLogger
+    @ApiLogger(option = "notice")
     @GetMapping("/all")
     public ResponseEntity<ToJsonArray> findNoticeList(
         @RequestParam(required = false) Optional<Integer> page) {
@@ -48,7 +48,7 @@ public class NoticeController {
         return new ResponseEntity<ToJsonArray>(data, header, HttpStatus.valueOf(200));
     }
 
-    @ApiLogger
+    @ApiLogger(option = "notice")
     @GetMapping("/")
     public ResponseEntity<ToJsonArray> findNoticeByNoticeId(@RequestParam Long noticeId) {
         HttpHeaders header = new HttpHeaders();
@@ -57,7 +57,7 @@ public class NoticeController {
         return new ResponseEntity<ToJsonArray>(data, header, HttpStatus.valueOf(200));
     }
 
-    @ApiLogger
+    @ApiLogger(option = "notice")
     @PostMapping("/")
     public ResponseEntity<String> saveNotice(@RequestBody NoticeSaveOrUpdateDto dto,
         @RequestHeader String Authorization) {
@@ -74,7 +74,7 @@ public class NoticeController {
         }
     }
 
-    @ApiLogger
+    @ApiLogger(option = "notice")
     @PutMapping("/")
     public ResponseEntity<String> updateNotice(@RequestParam Long noticeId,
         @RequestBody NoticeSaveOrUpdateDto dto, @RequestHeader String Authorization) {
@@ -91,7 +91,7 @@ public class NoticeController {
         }
     }
 
-    @ApiLogger
+    @ApiLogger(option = "notice")
     @DeleteMapping("/")
     public ResponseEntity<String> deleteNotice(@RequestParam Long noticeId,
         @RequestHeader String Authorization) {

--- a/src/main/java/usw/suwiki/domain/user/controller/UserController.java
+++ b/src/main/java/usw/suwiki/domain/user/controller/UserController.java
@@ -71,7 +71,7 @@ public class UserController {
     private final UserLoadRestrictAndBlackListReasonService userLoadRestrictAndBlackListReasonService;
 
     //아이디 중복확인
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("check-id")
     public ResponseEntity<Map<String, Boolean>> overlapId(
         @Valid @RequestBody CheckLoginIdForm checkLoginIdForm) {
@@ -81,7 +81,7 @@ public class UserController {
     }
 
     //이메일 중복 확인
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("check-email")
     public ResponseEntity<Map<String, Boolean>> overlapEmail(
         @Valid @RequestBody CheckEmailForm checkEmailForm) {
@@ -91,7 +91,7 @@ public class UserController {
     }
 
     //회원가입 버튼 클릭 시 -> 유저 저장, 인증 이메일 발송
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("join")
     public ResponseEntity<Map<String, Boolean>> join(@Valid @RequestBody JoinForm joinForm) {
         return ResponseEntity
@@ -100,7 +100,7 @@ public class UserController {
     }
 
     // 이메일 인증 링크를 눌렀을 때
-    @ApiLogger
+    @ApiLogger(option = "user")
     @GetMapping("verify-email")
     public ResponseEntity<String> confirmEmail(@RequestParam("token") String token) {
         return ResponseEntity
@@ -109,7 +109,7 @@ public class UserController {
     }
 
     //아이디 찾기 요청 시
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("find-id")
     public ResponseEntity<Map<String, Boolean>> findId(@Valid @RequestBody FindIdForm findIdForm) {
         return ResponseEntity
@@ -118,7 +118,7 @@ public class UserController {
     }
 
     //비밀번호 찾기 요청 시
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("find-pw")
     public ResponseEntity<Map<String, Boolean>> findPw(
         @Valid @RequestBody FindPasswordForm findPasswordForm) {
@@ -128,7 +128,7 @@ public class UserController {
     }
 
     //비밀번호 재설정 요청 시
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("reset-pw")
     public ResponseEntity<Map<String, Boolean>> resetPw(
         @Valid @RequestBody EditMyPasswordForm editMyPasswordForm,
@@ -139,7 +139,7 @@ public class UserController {
     }
 
     // 안드, IOS 로그인 요청 시
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("login")
     public ResponseEntity<Map<String, String>> mobileLogin(
         @Valid @RequestBody LoginForm loginForm) {
@@ -149,7 +149,7 @@ public class UserController {
     }
 
     // 프론트 로그인 요청 시 --> RefreshToken, AccessToken 쿠키로 셋팅
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("client-login")
     public ResponseEntity<Map<String, String>> clientLogin(
         @Valid @RequestBody LoginForm loginForm, HttpServletResponse response) {
@@ -167,7 +167,7 @@ public class UserController {
     }
 
     // 프론트 로그아웃
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("client-logout")
     public ResponseEntity<Map<String, Boolean>> clientLogout(HttpServletResponse response) {
         Cookie refreshCookie = new Cookie("refreshToken", "");
@@ -180,7 +180,7 @@ public class UserController {
             }});
     }
 
-    @ApiLogger
+    @ApiLogger(option = "user")
     @GetMapping("/my-page")
     public ResponseEntity<MyPageForm> myPage(@Valid @RequestHeader String Authorization) {
         return ResponseEntity
@@ -189,7 +189,7 @@ public class UserController {
     }
 
     // Web 토큰 갱신
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("/client-refresh")
     public ResponseEntity<Map<String, String>> clientTokenRefresh(
         @CookieValue(value = "refreshToken") Cookie requestRefreshCookie,
@@ -209,7 +209,7 @@ public class UserController {
     }
 
     // Mobile 토큰 갱신
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("/refresh")
     public ResponseEntity<Map<String, String>> tokenRefresh(
         @Valid @RequestHeader String Authorization) {
@@ -219,7 +219,7 @@ public class UserController {
     }
 
     // 회원 탈퇴
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("quit")
     public ResponseEntity<Map<String, Boolean>> userQuit(
         @Valid @RequestBody UserQuitForm userQuitForm, @Valid @RequestHeader String Authorization) {
@@ -229,7 +229,7 @@ public class UserController {
     }
 
     // 강의평가 신고
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("/report/evaluate")
     public ResponseEntity<Map<String, Boolean>> reportEvaluate(
         @Valid @RequestBody EvaluateReportForm evaluateReportForm,
@@ -240,7 +240,7 @@ public class UserController {
     }
 
     // 시험정보 신고
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("/report/exam")
     public ResponseEntity<Map<String, Boolean>> reportExam(
         @Valid @RequestBody ExamReportForm examReportForm,
@@ -251,7 +251,7 @@ public class UserController {
     }
 
     // 전공 즐겨찾기 등록하기
-    @ApiLogger
+    @ApiLogger(option = "user")
     @PostMapping("/favorite-major")
     public ResponseEntity<String> saveFavoriteMajor(
         @RequestHeader String Authorization, @RequestBody FavoriteSaveDto favoriteSaveDto) {
@@ -262,7 +262,7 @@ public class UserController {
     }
 
     // 전공 즐겨찾기 삭제하기
-    @ApiLogger
+    @ApiLogger(option = "user")
     @DeleteMapping("/favorite-major")
     public ResponseEntity<String> deleteFavoriteMajor(
         @RequestHeader String Authorization, @RequestParam String majorType) {
@@ -273,7 +273,7 @@ public class UserController {
     }
 
     // 전공 즐겨찾기 불러오기
-    @ApiLogger
+    @ApiLogger(option = "user")
     @GetMapping("/favorite-major")
     public ResponseEntity<ToJsonArray> findByLecture(@RequestHeader String Authorization) {
         return ResponseEntity
@@ -282,7 +282,7 @@ public class UserController {
     }
 
     // 땡큐 영수형
-    @ApiLogger
+    @ApiLogger(option = "user")
     @GetMapping("/suki")
     public String thanksToSuki() {
         return
@@ -296,7 +296,7 @@ public class UserController {
     }
 
     // 정지 사유 불러오기
-    @ApiLogger
+    @ApiLogger(option = "user")
     @GetMapping("/restricted-reason")
     public ResponseEntity<List<LoadMyRestrictedReasonForm>> restrictedReason(
         @Valid @RequestHeader String Authorization) {
@@ -307,7 +307,7 @@ public class UserController {
     }
 
     // 블랙리스트 사유 불러오기
-    @ApiLogger
+    @ApiLogger(option = "user")
     @GetMapping("/blacklist-reason")
     public ResponseEntity<List<LoadMyBlackListReasonForm>> banReason(
         @Valid @RequestHeader String Authorization) {

--- a/src/main/java/usw/suwiki/global/VersionController.java
+++ b/src/main/java/usw/suwiki/global/VersionController.java
@@ -19,7 +19,7 @@ public class VersionController {
 
     private final LectureService lectureService;
 
-    @ApiLogger
+    @ApiLogger(option = "version")
     @GetMapping("/version")
     public ResponseEntity<VersionResponseDto> findVersionSuwiki() {
         HttpHeaders header = new HttpHeaders();
@@ -28,7 +28,7 @@ public class VersionController {
         return new ResponseEntity<VersionResponseDto>(dto, header, HttpStatus.valueOf(200));
     }
 
-    @ApiLogger
+    @ApiLogger(option = "version")
     @GetMapping("/majorType")
     public ResponseEntity<ToJsonArray> findAllMajorType() {
         HttpHeaders header = new HttpHeaders();

--- a/src/main/java/usw/suwiki/global/annotation/ApiLogAspect.java
+++ b/src/main/java/usw/suwiki/global/annotation/ApiLogAspect.java
@@ -19,7 +19,8 @@ public class ApiLogAspect {
     private final ApiLoggerService apiLoggerService;
 
     @Around("@annotation(ApiLogger)")
-    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint, ApiLogger ApiLogger
+    ) throws Throwable {
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
 
@@ -27,7 +28,9 @@ public class ApiLogAspect {
 
         stopWatch.stop();
 
-        apiLoggerService.logApi(LocalDate.now(), stopWatch.getTotalTimeMillis());
+        String option = ApiLogger.option();
+
+        apiLoggerService.logApi(LocalDate.now(), stopWatch.getTotalTimeMillis(), option);
         return proceed;
     }
 }

--- a/src/main/java/usw/suwiki/global/annotation/ApiLogger.java
+++ b/src/main/java/usw/suwiki/global/annotation/ApiLogger.java
@@ -8,5 +8,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiLogger {
-
+    String option();
 }


### PR DESCRIPTION
# 기존 문제점

- 모든 API의 평균 처리 시간과 API 호출 횟수를 종합하여 기록하는 방식으로 어떤 API가 자주 사용되는지에 대한 통계가 부족했습니다.

# 개선점

- 각 도메인에 해당하는 Controller메서드에 ApiLogger 애노테이션의 옵션을 추가하여 어떤 도메인에 대한 API를 호출했는지 구분 할 수 있도록 변경하기로 했습니다.
- 따라서 ApiLogger 엔티티 클래스에 컬럼이 추가되었습니다.
- api_logger의 스키마가 변경되었습니다.
- ApiLoggerService의 비즈니스 로직이 변경되었습니다.