### PR TITLE
Fix : 강의 정보 Lost Update 락을 통한 해결

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,13 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="fd8b60d8-83aa-4517-8f76-72f1a7b48cad" name="변경" comment="# &lt;타입&gt;: &lt;제목&gt;&#10;&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------" />
+    <list default="true" id="fd8b60d8-83aa-4517-8f76-72f1a7b48cad" name="변경" comment="# &lt;타입&gt;: &lt;제목&gt;&#10;&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/evaluation/service/EvaluatePostsService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/evaluation/service/EvaluatePostsService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/lecture/entity/Lecture.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/lecture/entity/Lecture.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/lecture/repository/LectureRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/lecture/repository/LectureRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -48,7 +54,7 @@
   <component name="Git.Settings">
     <option name="RECENT_BRANCH_BY_REPOSITORY">
       <map>
-        <entry key="$PROJECT_DIR$" value="refactor/lecture_entity" />
+        <entry key="$PROJECT_DIR$" value="main" />
       </map>
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
@@ -163,11 +169,16 @@
     <key name="CreateTestDialog.Recents.Supers">
       <recent name="" />
     </key>
+    <key name="MoveClassesOrPackagesDialog.RECENTS_KEY">
+      <recent name="usw.suwiki.domain.lecture.entity" />
+    </key>
     <key name="CreateTestDialog.RecentsKey">
       <recent name="usw.suwiki.domain.user.repository" />
       <recent name="usw.suwiki.testPackage" />
     </key>
     <key name="CopyClassDialog.RECENTS_KEY">
+      <recent name="usw.suwiki.domain.lecture.entity" />
+      <recent name="usw.suwiki.domain.lecture.repository.dao" />
       <recent name="usw.suwiki.global.util.emailBuild" />
       <recent name="usw.suwiki.domain.user.service.usecase" />
     </key>
@@ -715,7 +726,19 @@
         </entry>
         <entry key="MAIN">
           <value>
-            <State />
+            <State>
+              <option name="FILTERS">
+                <map>
+                  <entry key="branch">
+                    <value>
+                      <list>
+                        <option value="refactor/동시성문제_해결" />
+                      </list>
+                    </value>
+                  </entry>
+                </map>
+              </option>
+            </State>
           </value>
         </entry>
       </map>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,18 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="db0b6a8e-5ee2-4766-83ca-070d992366d0" name="변경" comment="# &lt;타입&gt;: &lt;제목&gt;&#10;&#10;##### 제목은 최대 50 글자까지만 입력 ############## -&gt; |&#10;&#10;&#10;# 본문은 위에 작성&#10;######## 본문은 한 줄에 최대 72 글자까지만 입력 ########################### -&gt; |&#10;&#10;# 꼬릿말은 아래에 작성: ex) #이슈 번호&#10;&#10;# --- COMMIT END ---&#10;# &lt;타입&gt; 리스트&#10;#   feat    : 기능 (새로운 기능)&#10;#   fix     : 버그 (버그 수정)&#10;#   refactor: 리팩토링&#10;#   style   : 스타일 (코드 형식, 세미콜론 추가: 비즈니스 로직에 변경 없음)&#10;#   docs    : 문서 (문서 추가, 수정, 삭제)&#10;#   test    : 테스트 (테스트 코드 추가, 수정, 삭제: 비즈니스 로직에 변경 없음)&#10;#   chore   : 기타 변경사항 (빌드 스크립트 수정 등)&#10;# ------------------&#10;#     제목 첫 글자를 대문자로&#10;#     제목은 명령문으로&#10;#     제목 끝에 마침표(.) 금지&#10;#     제목과 본문을 한 줄 띄워 분리하기&#10;#     본문은 &quot;어떻게&quot; 보다 &quot;무엇을&quot;, &quot;왜&quot;를 설명한다.&#10;#     본문에 여러줄의 메시지를 작성할 땐 &quot;-&quot;로 구분&#10;# ------------------">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/admin/controller/UserAdminController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/admin/controller/UserAdminController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/apilogger/ApiLogger.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/apilogger/ApiLogger.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/apilogger/service/ApiLoggerService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/apilogger/service/ApiLoggerService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/evaluation/controller/EvaluateController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/evaluation/controller/EvaluateController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/exam/controller/ExamPostsController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/exam/controller/ExamPostsController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/lecture/controller/LectureController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/lecture/controller/LectureController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/notice/controller/NoticeController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/notice/controller/NoticeController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/user/controller/UserController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/user/controller/UserController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/global/VersionController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/global/VersionController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/global/annotation/ApiLogAspect.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/global/annotation/ApiLogAspect.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/usw/suwiki/global/annotation/ApiLogger.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/usw/suwiki/global/annotation/ApiLogger.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -40,17 +30,6 @@
               <path>
                 <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
                 <item name="suwiki" type="f1a62948:ProjectNode" />
-              </path>
-              <path>
-                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
-                <item name="suwiki" type="f1a62948:ProjectNode" />
-                <item name="Tasks" type="e4a08cd1:TasksNode" />
-              </path>
-              <path>
-                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
-                <item name="suwiki" type="f1a62948:ProjectNode" />
-                <item name="Tasks" type="e4a08cd1:TasksNode" />
-                <item name="other" type="c8890929:TasksNode$1" />
               </path>
             </expand>
             <select />
@@ -124,6 +103,7 @@
     </option>
   </component>
   <component name="HighlightingSettingsPerFile">
+    <setting file="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.springframework/spring-web/5.3.15/dc77bfb04059f61b04184ec434fe3494c5079286/spring-web-5.3.15-sources.jar!/org/springframework/http/HttpStatus.java" root0="SKIP_INSPECTION" />
     <setting file="file://$PROJECT_DIR$/src/main/java/usw/suwiki/domain/exam/dto/ExamPostsSaveDto.java" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/src/main/java/usw/suwiki/domain/user/controller/UserController.java" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/src/main/java/usw/suwiki/domain/user/service/UserCommonService.java" root0="FORCE_HIGHLIGHTING" />
@@ -151,6 +131,7 @@
     <option name="stateVersion" value="1" />
   </component>
   <component name="ProjectId" id="27WOzAspncOFgOidFe1zNLhibFE" />
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
     <option name="sortByType" value="true" />

--- a/src/main/java/usw/suwiki/domain/lecture/controller/LectureController.java
+++ b/src/main/java/usw/suwiki/domain/lecture/controller/LectureController.java
@@ -67,10 +67,10 @@ public class LectureController {
             .pageNumber(page).majorType(majorType).build();
         if (findOption.getMajorType().get().equals("")) {
             LectureToJsonArray data = lectureService.findAllLectureByFindOption(findOption);
-            return new ResponseEntity<LectureToJsonArray>(data, header, HttpStatus.valueOf(200));
+            return new ResponseEntity<>(data, header, HttpStatus.valueOf(200));
         } else {
             LectureToJsonArray data = lectureService.findAllLectureByMajorType(findOption);
-            return new ResponseEntity<LectureToJsonArray>(data, header, HttpStatus.valueOf(200));
+            return new ResponseEntity<>(data, header, HttpStatus.valueOf(200));
         }
     }
 

--- a/src/main/java/usw/suwiki/domain/lecture/entity/Lecture.java
+++ b/src/main/java/usw/suwiki/domain/lecture/entity/Lecture.java
@@ -76,48 +76,6 @@ public class Lecture extends BaseTimeEntity {
         this.grade = grade;
     }
 
-
-    public void addLectureValue(EvaluatePostsToLecture dto) {
-        this.lectureSatisfactionValue += dto.getLectureSatisfaction();
-        this.lectureHoneyValue += dto.getLectureHoney();
-        this.lectureLearningValue += dto.getLectureLearning();
-        this.lectureTeamValue += dto.getLectureTeam();
-        this.lectureDifficultyValue += dto.getLectureDifficulty();
-        this.lectureHomeworkValue += dto.getLectureHomework();
-        this.postsCount += 1;
-    }
-
-    public void cancelLectureValue(EvaluatePostsToLecture dto) {
-        this.lectureSatisfactionValue -= dto.getLectureSatisfaction();
-        this.lectureHoneyValue -= dto.getLectureHoney();
-        this.lectureLearningValue -= dto.getLectureLearning();
-        this.lectureTeamValue -= dto.getLectureTeam();
-        this.lectureDifficultyValue -= dto.getLectureDifficulty();
-        this.lectureHomeworkValue -= dto.getLectureHomework();
-        this.postsCount -= 1;
-    }
-
-    public void calcLectureAvg() {
-        if (postsCount < 1) {
-            this.lectureTotalAvg = 0;
-            this.lectureSatisfactionAvg = 0;
-            this.lectureHoneyAvg = 0;
-            this.lectureLearningAvg = 0;
-            this.lectureTeamAvg = 0;
-            this.lectureDifficultyAvg = 0;
-            this.lectureHomeworkAvg = 0;
-        } else {
-            this.lectureSatisfactionAvg = lectureSatisfactionValue / postsCount;
-            this.lectureHoneyAvg = lectureHoneyValue / postsCount;
-            this.lectureLearningAvg = lectureLearningValue / postsCount;
-            this.lectureTeamAvg = lectureTeamValue / postsCount;
-            this.lectureDifficultyAvg = lectureDifficultyValue / postsCount;
-            this.lectureHomeworkAvg = lectureHomeworkValue / postsCount;
-            this.lectureTotalAvg = (lectureSatisfactionAvg + lectureHoneyAvg + lectureLearningAvg) / 3;
-        }
-    }
-
-
     public void toEntity(JsonToLectureDto dto) {
         this.semesterList = dto.getSelectedSemester();
         this.placeSchedule = dto.getPlaceSchedule();
@@ -132,4 +90,60 @@ public class Lecture extends BaseTimeEntity {
         this.capprType = dto.getCapprType();
     }
 
+
+    public void handleLectureEvaluationIfNewPost(EvaluatePostsToLecture post) {
+        this.addLectureEvaluation(post);
+        this.calculateAverage();
+    }
+
+    public void handleLectureEvaluationIfUpdatePost(EvaluatePostsToLecture beforeUpdatePost, EvaluatePostsToLecture updatePost) {
+        this.cancelLectureEvaluation(beforeUpdatePost);
+        this.addLectureEvaluation(updatePost);
+        this.calculateAverage();
+    }
+
+    public void handleLectureEvaluationIfDeletePost(EvaluatePostsToLecture post) {
+        this.cancelLectureEvaluation(post);
+        this.calculateAverage();
+    }
+
+    private void addLectureEvaluation(EvaluatePostsToLecture dto) {
+        this.lectureSatisfactionValue += dto.getLectureSatisfaction();
+        this.lectureHoneyValue += dto.getLectureHoney();
+        this.lectureLearningValue += dto.getLectureLearning();
+        this.lectureTeamValue += dto.getLectureTeam();
+        this.lectureDifficultyValue += dto.getLectureDifficulty();
+        this.lectureHomeworkValue += dto.getLectureHomework();
+        this.postsCount += 1;
+    }
+
+    private void cancelLectureEvaluation(EvaluatePostsToLecture dto) {
+        this.lectureSatisfactionValue -= dto.getLectureSatisfaction();
+        this.lectureHoneyValue -= dto.getLectureHoney();
+        this.lectureLearningValue -= dto.getLectureLearning();
+        this.lectureTeamValue -= dto.getLectureTeam();
+        this.lectureDifficultyValue -= dto.getLectureDifficulty();
+        this.lectureHomeworkValue -= dto.getLectureHomework();
+        this.postsCount -= 1;
+    }
+
+    private void calculateAverage() {
+        if (postsCount < 1) {
+            this.lectureTotalAvg = 0;
+            this.lectureSatisfactionAvg = 0;
+            this.lectureHoneyAvg = 0;
+            this.lectureLearningAvg = 0;
+            this.lectureTeamAvg = 0;
+            this.lectureDifficultyAvg = 0;
+            this.lectureHomeworkAvg = 0;
+            return;
+        }
+        this.lectureSatisfactionAvg = lectureSatisfactionValue / postsCount;
+        this.lectureHoneyAvg = lectureHoneyValue / postsCount;
+        this.lectureLearningAvg = lectureLearningValue / postsCount;
+        this.lectureTeamAvg = lectureTeamValue / postsCount;
+        this.lectureDifficultyAvg = lectureDifficultyValue / postsCount;
+        this.lectureHomeworkAvg = lectureHomeworkValue / postsCount;
+        this.lectureTotalAvg = (lectureSatisfactionAvg + lectureHoneyAvg + lectureLearningAvg) / 3;
+    }
 }

--- a/src/main/java/usw/suwiki/domain/lecture/repository/JpaLectureRepository.java
+++ b/src/main/java/usw/suwiki/domain/lecture/repository/JpaLectureRepository.java
@@ -8,6 +8,8 @@ import usw.suwiki.global.exception.errortype.AccountException;
 import usw.suwiki.global.exception.ErrorType;
 
 import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -23,6 +25,12 @@ public class JpaLectureRepository implements LectureRepository {
     @Override
     public void save(Lecture lecture) {
         em.persist(lecture);
+    }
+
+    @Override
+    public Lecture findByIdPessimisticLock(Long id) {
+        Lecture lecture = em.find(Lecture.class, id, LockModeType.PESSIMISTIC_WRITE);
+        return lecture;
     }
 
     @Override

--- a/src/main/java/usw/suwiki/domain/lecture/repository/LectureRepository.java
+++ b/src/main/java/usw/suwiki/domain/lecture/repository/LectureRepository.java
@@ -15,6 +15,8 @@ public interface LectureRepository {
 
     Lecture findById(Long id);
 
+    Lecture findByIdPessimisticLock(Long id);
+
     LectureListAndCountDto findLectureByFindOption(String searchValue, LectureFindOption lectureFindOption);
 
     LectureListAndCountDto findLectureByMajorType(String searchValue, LectureFindOption lectureFindOption);

--- a/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
+++ b/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
@@ -22,19 +22,19 @@ public class LectureService {
 
     private final LectureRepository lectureRepository;
 
-    public void cancelLectureValue(EvaluatePostsToLecture dto) {
-        Lecture lecture = lectureRepository.findById(dto.getLectureId());
-        lecture.cancelLectureValue(dto);
+    public void updateLectureEvaluationIfCreateNewPost(EvaluatePostsToLecture post) {
+        Lecture lecture = lectureRepository.findByIdPessimisticLock(post.getLectureId());
+        lecture.handleLectureEvaluationIfNewPost(post);
     }
 
-    public void addLectureValue(EvaluatePostsToLecture dto) {
-        Lecture lecture = lectureRepository.findById(dto.getLectureId());
-        lecture.addLectureValue(dto);
+    public void updateLectureEvaluationIfUpdatePost(EvaluatePostsToLecture beforeUpdatePost, EvaluatePostsToLecture post) {
+        Lecture lecture = lectureRepository.findByIdPessimisticLock(post.getLectureId());
+        lecture.handleLectureEvaluationIfUpdatePost(beforeUpdatePost, post);
     }
 
-    public void calcLectureAvg(EvaluatePostsToLecture dto) {
-        Lecture lecture = lectureRepository.findById(dto.getLectureId());
-        lecture.calcLectureAvg();
+    public void updateLectureEvaluationIfDeletePost(EvaluatePostsToLecture post) {
+        Lecture lecture = lectureRepository.findByIdPessimisticLock(post.getLectureId());
+        lecture.handleLectureEvaluationIfDeletePost(post);
     }
 
     public LectureToJsonArray findAllLectureByFindOption(LectureFindOption lectureFindOption) {

--- a/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
+++ b/src/main/java/usw/suwiki/domain/lecture/service/LectureService.java
@@ -2,6 +2,8 @@ package usw.suwiki.domain.lecture.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import usw.suwiki.domain.evaluation.EvaluatePostsToLecture;
 import usw.suwiki.domain.lecture.LectureFindOption;
 import usw.suwiki.domain.lecture.LectureToJsonArray;
@@ -11,16 +13,71 @@ import usw.suwiki.domain.lecture.dto.LectureResponseDto;
 import usw.suwiki.domain.lecture.entity.Lecture;
 import usw.suwiki.domain.lecture.repository.LectureRepository;
 
-import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
-@Transactional
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class LectureService {
 
     private final LectureRepository lectureRepository;
+
+    @Transactional(readOnly = true)
+    public LectureToJsonArray findAllLectureByFindOption(LectureFindOption lectureFindOption) {
+        List<LectureResponseDto> dtoList = new ArrayList<>();
+        LectureListAndCountDto dto = lectureRepository.findAllLectureByFindOption(lectureFindOption);
+        for (Lecture lecture : dto.getLectureList()) {
+            dtoList.add(new LectureResponseDto(lecture));
+        }
+
+        return new LectureToJsonArray(dtoList, dto.getCount());
+    }
+
+    @Transactional(readOnly = true)
+    public LectureToJsonArray findAllLectureByMajorType(LectureFindOption lectureFindOption) {
+        List<LectureResponseDto> dtoList = new ArrayList<>();
+        LectureListAndCountDto dto = lectureRepository.findAllLectureByMajorType(lectureFindOption);
+        for (Lecture lecture : dto.getLectureList()) {
+            dtoList.add(new LectureResponseDto(lecture));
+        }
+
+        return new LectureToJsonArray(dtoList, dto.getCount());
+    }
+
+    @Transactional(readOnly = true)
+    public LectureToJsonArray findLectureByFindOption(String searchValue, LectureFindOption lectureFindOption) {
+        List<LectureResponseDto> dtoList = new ArrayList<>();
+        LectureListAndCountDto dto = lectureRepository.findLectureByFindOption(searchValue, lectureFindOption);
+        for (Lecture lecture : dto.getLectureList()) {
+            dtoList.add(new LectureResponseDto(lecture));
+        }
+
+        return new LectureToJsonArray(dtoList, dto.getCount());
+    }
+
+    @Transactional(readOnly = true)
+    public LectureToJsonArray findLectureByMajorType(String searchValue, LectureFindOption lectureFindOption) {
+        List<LectureResponseDto> dtoList = new ArrayList<>();
+        LectureListAndCountDto dto = lectureRepository.findLectureByMajorType(searchValue, lectureFindOption);
+        for (Lecture lecture : dto.getLectureList()) {
+            dtoList.add(new LectureResponseDto(lecture));
+        }
+
+        return new LectureToJsonArray(dtoList, dto.getCount());
+    }
+
+    @Transactional(readOnly = true)
+    public LectureDetailResponseDto findByIdDetail(Long id) {
+        Lecture lecture = lectureRepository.findById(id);
+        LectureDetailResponseDto dto = new LectureDetailResponseDto(lecture);
+        return dto;
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> findAllMajorType() {
+        List<String> resultList = lectureRepository.findAllMajorType();
+        return resultList;
+    }
 
     public void updateLectureEvaluationIfCreateNewPost(EvaluatePostsToLecture post) {
         Lecture lecture = lectureRepository.findByIdPessimisticLock(post.getLectureId());
@@ -37,59 +94,7 @@ public class LectureService {
         lecture.handleLectureEvaluationIfDeletePost(post);
     }
 
-    public LectureToJsonArray findAllLectureByFindOption(LectureFindOption lectureFindOption) {
-        List<LectureResponseDto> dtoList = new ArrayList<>();
-        LectureListAndCountDto dto = lectureRepository.findAllLectureByFindOption(lectureFindOption);
-        for (Lecture lecture : dto.getLectureList()) {
-            dtoList.add(new LectureResponseDto(lecture));
-        }
-
-        return new LectureToJsonArray(dtoList, dto.getCount());
-    }
-
-    public LectureToJsonArray findAllLectureByMajorType(LectureFindOption lectureFindOption) {
-        List<LectureResponseDto> dtoList = new ArrayList<>();
-        LectureListAndCountDto dto = lectureRepository.findAllLectureByMajorType(lectureFindOption);
-        for (Lecture lecture : dto.getLectureList()) {
-            dtoList.add(new LectureResponseDto(lecture));
-        }
-
-        return new LectureToJsonArray(dtoList, dto.getCount());
-    }
-
-    public LectureToJsonArray findLectureByFindOption(String searchValue, LectureFindOption lectureFindOption) {
-        List<LectureResponseDto> dtoList = new ArrayList<>();
-        LectureListAndCountDto dto = lectureRepository.findLectureByFindOption(searchValue, lectureFindOption);
-        for (Lecture lecture : dto.getLectureList()) {
-            dtoList.add(new LectureResponseDto(lecture));
-        }
-
-        return new LectureToJsonArray(dtoList, dto.getCount());
-    }
-
-    public LectureToJsonArray findLectureByMajorType(String searchValue, LectureFindOption lectureFindOption) {
-        List<LectureResponseDto> dtoList = new ArrayList<>();
-        LectureListAndCountDto dto = lectureRepository.findLectureByMajorType(searchValue, lectureFindOption);
-        for (Lecture lecture : dto.getLectureList()) {
-            dtoList.add(new LectureResponseDto(lecture));
-        }
-
-        return new LectureToJsonArray(dtoList, dto.getCount());
-    }
-
-    public LectureDetailResponseDto findByIdDetail(Long id) {
-        Lecture lecture = lectureRepository.findById(id);
-        LectureDetailResponseDto dto = new LectureDetailResponseDto(lecture);
-        return dto;
-    }
-
     public Lecture findById(Long id) {
         return lectureRepository.findById(id);
     }
-
-    public List<String> findAllMajorType() {
-        List<String> resultList = lectureRepository.findAllMajorType();
-        return resultList;
-    }
-
 }

--- a/src/main/java/usw/suwiki/global/VersionController.java
+++ b/src/main/java/usw/suwiki/global/VersionController.java
@@ -34,6 +34,6 @@ public class VersionController {
         HttpHeaders header = new HttpHeaders();
         List<String> list = lectureService.findAllMajorType();
         ToJsonArray data = new ToJsonArray(list);
-        return new ResponseEntity<ToJsonArray>(data, header, HttpStatus.valueOf(200));
+        return new ResponseEntity<>(data, header, HttpStatus.valueOf(200));
     }
 }


### PR DESCRIPTION
## 기존 문제점 
- 강의에 대한 평가에 대한 데이터에 동시 접근 할 경우 발생하는 문제점이 있었습니다.
- 예를들어, 어떤 강의를 한명은 강의에 대한 평가를 작성하고, 한명은 강의에 대한 삭제를 할 경우 LostUpdate 현상이 발생 할 수 있습니다. 

## 고민
- 비관적 락을 사용할지, Version 을 이용한 낙관적 락을 사용할지에 대한 고민을 하였습니다.

## 해결
- 비관적 락을 사용하여 해결하였습니다. 
- 강의에 대한 총 평가 같은 데이터는 여러 사용자가 동시에 접근하고 수정할 가능성이 있기 때문에, 
데이터가 충돌 날 경우 처리 하는 과정이 오히려 더 큰 리소스가 들수 있기 때문에 비관적 락을 사용하였습니다.